### PR TITLE
Added idle nice and idle IO scheduling to node systemd services.

### DIFF
--- a/backend/systemd/node.service
+++ b/backend/systemd/node.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=node
-After=multi-user.target 
+After=multi-user.target
 After=apollo-ui-v2.service
 After=dev-nvme0n1.device
 
 [Service]
 Type=forking
 User=futurebit
+Nice=19
+IOSchedulingClass=idle
 #Start:
 ExecStart=/opt/apolloapi/backend/node/node_start.sh
 #WorkingDirectory=/opt/apolloapi/backend/node


### PR DESCRIPTION
This addresses bitcoind overloading the system during IBD, causing latency and TCP/IP connection loss.