### PR TITLE
Relocate mutable state out of the code checkout

### DIFF
--- a/backend/apollo-miner/miner_start.sh
+++ b/backend/apollo-miner/miner_start.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-cd /opt/apolloapi/backend/apollo-miner
+# Binaries stay in the code checkout; the regenerated runtime data (miner_config,
+# mode, apollo-miner.* stat files) lives outside it so the checkout stays clean
+# for prebuilt OTA updates. The bootstrap creates RUNTIME_DIR (futurebit-owned)
+# before this unit runs; mkdir -p here is only a fallback.
+BIN_DIR=/opt/apolloapi/backend/apollo-miner
+STATE_DIR="${APOLLO_STATE_DIR:-/var/lib/apollo}"
+RUNTIME_DIR="${STATE_DIR}/miner"
+
+mkdir -p "$RUNTIME_DIR"
+cd "$RUNTIME_DIR"
+
 settings=$(cat miner_config)
 mode=$(cat mode)
 
@@ -8,24 +18,24 @@ start_hashboards()
 {
     while [ $1 ];
             do
-            
-            local boardType=$(./apollo-helper -s $1)
-            
+
+            local boardType=$("$BIN_DIR"/apollo-helper -s $1)
+
             if [[ "$boardType" == *"Apollo-BTC"* || "$boardType" == *"RD6"* ]]; then
-  				screen -dmS miner ./futurebit-miner -comport $1 -ao_mode 1 $settings -powermode $mode
+  				screen -dmS miner "$BIN_DIR"/futurebit-miner -comport $1 -ao_mode 1 $settings -powermode $mode
 			elif [[ "$boardType" == *"Apollo-2"* ]]; then
-  				screen -dmS miner ./futurebit-miner-v2 -comport $1 -ao_mode 1 $settings -powermode $mode
+  				screen -dmS miner "$BIN_DIR"/futurebit-miner-v2 -comport $1 -ao_mode 1 $settings -powermode $mode
   			else
   			    echo "unknown USB board"
   			fi
-            
+
             sleep 1
             shift
     done
 }
 
 #clear old log files
-rm apollo-miner*
+rm -f apollo-miner*
 
 #reset internal hashboard
 gpio write 0 0
@@ -35,12 +45,12 @@ gpio write 0 1
 sleep 35
 #start internal hashboard
 
-boardType=$(./apollo-helper -s /dev/ttyS1)
-            
+boardType=$("$BIN_DIR"/apollo-helper -s /dev/ttyS1)
+
 if [[ "$boardType" == *"Apollo-BTC"* || "$boardType" == *"RD6"* ]]; then
-  	screen -dmS miner ./futurebit-miner -comport /dev/ttyS1 -ao_mode 1 $settings -powermode $mode
+  	screen -dmS miner "$BIN_DIR"/futurebit-miner -comport /dev/ttyS1 -ao_mode 1 $settings -powermode $mode
 elif [[ "$boardType" == *"Apollo-2"* ]]; then
-  	screen -dmS miner ./futurebit-miner-v2 -comport /dev/ttyS1 -ao_mode 1 $settings -powermode $mode
+  	screen -dmS miner "$BIN_DIR"/futurebit-miner-v2 -comport /dev/ttyS1 -ao_mode 1 $settings -powermode $mode
 else
   	echo "internal board error"
 fi

--- a/backend/systemd/apollo-miner.service
+++ b/backend/systemd/apollo-miner.service
@@ -1,10 +1,14 @@
 [Unit]
 Description=apollo-miner
-After=network.target rc-local.service
+# Requires apollo-bootstrap so the futurebit-owned miner runtime dir exists
+# before this (root) unit writes stat files into it.
+Requires=apollo-bootstrap.service
+After=network.target rc-local.service apollo-bootstrap.service
 
 [Service]
 Type=forking
 User=root
+EnvironmentFile=-/opt/apolloapi/.env
 #Start:
 ExecStart=/opt/apolloapi/backend/apollo-miner/miner_start.sh
 WorkingDirectory=/opt/apolloapi/backend/apollo-miner

--- a/backend/update
+++ b/backend/update
@@ -8,37 +8,61 @@ TMPFILE='/tmp/update_progress'
 SOLO_REQUEST_FILE='/run/apollo-update-solo-requested-status'
 APOLLO_DIR='/opt/apolloapi'
 UI_DIR="${APOLLO_DIR}/apolloui-v2"
-DATABASE_URL="${APOLLO_DIR}/futurebit.sqlite"
+STATE_DIR="${APOLLO_STATE_DIR:-/var/lib/apollo}"
 
 if [ "$EUID" -ne 0 ]; then
     echo -e "${RED}Update script must be run by root or with sudo${NC}"
     exit 1
 fi
 
+# The API relocates the DB out of the checkout into the state dir (src/paths.js),
+# and that can happen while this script runs, so resolve the path at each use
+# instead of once at startup. .env is the source of truth, with the managed and
+# legacy locations as fallbacks.
+resolve_database_url() {
+    local from_env='' candidate
+    if [ -r "${APOLLO_DIR}/.env" ]; then
+        from_env=$(sed -n 's/^DATABASE_URL=//p' "${APOLLO_DIR}/.env" | tail -n 1)
+    fi
+    for candidate in "$from_env" "${STATE_DIR}/db/futurebit.sqlite" "${APOLLO_DIR}/futurebit.sqlite"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 restore_solo_intent() {
     [ -f "$SOLO_REQUEST_FILE" ] || return 0
 
-    if [ -f "$DATABASE_URL" ]; then
-        local requested_status
-        requested_status=$(<"$SOLO_REQUEST_FILE")
-        case "$requested_status" in
-            online|offline)
-                sqlite3 "$DATABASE_URL" \
-                    "UPDATE service_status
-                        SET status = 'pending',
-                            requested_status = '${requested_status}',
-                            requested_at = CURRENT_TIMESTAMP
-                      WHERE service_name = 'solo';"
-                ;;
-            '')
-                sqlite3 "$DATABASE_URL" \
-                    "UPDATE service_status
-                        SET requested_status = NULL,
-                            requested_at = NULL
-                      WHERE service_name = 'solo';"
-                ;;
-        esac
+    local database_url
+    if ! database_url=$(resolve_database_url); then
+        # Keep the marker so a later run can still restore the user's intent
+        # instead of silently dropping their solo-mining setting.
+        echo -e "${YELLOW}Could not locate the database; keeping preserved solo intent${NC}" >&2
+        return 0
     fi
+
+    local requested_status
+    requested_status=$(<"$SOLO_REQUEST_FILE")
+    case "$requested_status" in
+        online|offline)
+            sqlite3 "$database_url" \
+                "UPDATE service_status
+                    SET status = 'pending',
+                        requested_status = '${requested_status}',
+                        requested_at = CURRENT_TIMESTAMP
+                  WHERE service_name = 'solo';"
+            ;;
+        '')
+            sqlite3 "$database_url" \
+                "UPDATE service_status
+                    SET requested_status = NULL,
+                        requested_at = NULL
+                  WHERE service_name = 'solo';"
+            ;;
+    esac
 
     rm -f "$SOLO_REQUEST_FILE"
 }
@@ -58,8 +82,8 @@ echo "10" > "$TMPFILE"
 
 # Preserve solo intent across the first update to a monitor version that
 # understands the update marker. /run is root-owned and cleared on reboot.
-if [ ! -e "$SOLO_REQUEST_FILE" ] && [ -f "$DATABASE_URL" ]; then
-    requested_status=$(sqlite3 "$DATABASE_URL" \
+if [ ! -e "$SOLO_REQUEST_FILE" ] && preserve_db=$(resolve_database_url); then
+    requested_status=$(sqlite3 "$preserve_db" \
         "SELECT COALESCE(requested_status, '')
            FROM service_status
           WHERE service_name = 'solo'

--- a/backend/update_system
+++ b/backend/update_system
@@ -7,46 +7,76 @@ TMPFILE='/tmp/update_progress'
 SOLO_REQUEST_FILE='/run/apollo-update-solo-requested-status'
 APOLLO_DIR='/opt/apolloapi'
 UI_DIR="${APOLLO_DIR}/apolloui-v2"
-STATE_DIR='/var/lib/apollo'
-DATABASE_URL="${APOLLO_DIR}/futurebit.sqlite"
+STATE_DIR="${APOLLO_STATE_DIR:-/var/lib/apollo}"
+
+# The API relocates the DB out of the checkout into the state dir (src/paths.js),
+# and that can happen while this script runs, so resolve the path at each use
+# instead of once at startup. .env is the source of truth, with the managed and
+# legacy locations as fallbacks.
+resolve_database_url() {
+    local from_env='' candidate
+    if [ -r "${APOLLO_DIR}/.env" ]; then
+        from_env=$(sed -n 's/^DATABASE_URL=//p' "${APOLLO_DIR}/.env" | tail -n 1)
+    fi
+    for candidate in "$from_env" "${STATE_DIR}/db/futurebit.sqlite" "${APOLLO_DIR}/futurebit.sqlite"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
 
 preserve_solo_intent() {
-    if [ ! -e "$SOLO_REQUEST_FILE" ] && [ -f "$DATABASE_URL" ]; then
-        local requested_status
-        requested_status=$(sqlite3 "$DATABASE_URL" \
-            "SELECT COALESCE(requested_status, '')
-               FROM service_status
-              WHERE service_name = 'solo'
-              ORDER BY id DESC
-              LIMIT 1;" 2>/dev/null || true)
-        (umask 077; printf '%s\n' "$requested_status" > "$SOLO_REQUEST_FILE")
+    if [ -e "$SOLO_REQUEST_FILE" ]; then
+        return 0
     fi
+
+    local database_url
+    if ! database_url=$(resolve_database_url); then
+        return 0
+    fi
+
+    local requested_status
+    requested_status=$(sqlite3 "$database_url" \
+        "SELECT COALESCE(requested_status, '')
+           FROM service_status
+          WHERE service_name = 'solo'
+          ORDER BY id DESC
+          LIMIT 1;" 2>/dev/null || true)
+    (umask 077; printf '%s\n' "$requested_status" > "$SOLO_REQUEST_FILE")
 }
 
 restore_solo_intent() {
     [ -f "$SOLO_REQUEST_FILE" ] || return 0
 
-    if [ -f "$DATABASE_URL" ]; then
-        local requested_status
-        requested_status=$(<"$SOLO_REQUEST_FILE")
-        case "$requested_status" in
-            online|offline)
-                sqlite3 "$DATABASE_URL" \
-                    "UPDATE service_status
-                        SET status = 'pending',
-                            requested_status = '${requested_status}',
-                            requested_at = CURRENT_TIMESTAMP
-                      WHERE service_name = 'solo';"
-                ;;
-            '')
-                sqlite3 "$DATABASE_URL" \
-                    "UPDATE service_status
-                        SET requested_status = NULL,
-                            requested_at = NULL
-                      WHERE service_name = 'solo';"
-                ;;
-        esac
+    local database_url
+    if ! database_url=$(resolve_database_url); then
+        # Keep the marker so a later run can still restore the user's intent
+        # instead of silently dropping their solo-mining setting.
+        echo -e "${YELLOW}Could not locate the database; keeping preserved solo intent${NC}" >&2
+        return 0
     fi
+
+    local requested_status
+    requested_status=$(<"$SOLO_REQUEST_FILE")
+    case "$requested_status" in
+        online|offline)
+            sqlite3 "$database_url" \
+                "UPDATE service_status
+                    SET status = 'pending',
+                        requested_status = '${requested_status}',
+                        requested_at = CURRENT_TIMESTAMP
+                  WHERE service_name = 'solo';"
+            ;;
+        '')
+            sqlite3 "$database_url" \
+                "UPDATE service_status
+                    SET requested_status = NULL,
+                        requested_at = NULL
+                  WHERE service_name = 'solo';"
+            ;;
+    esac
 
     rm -f "$SOLO_REQUEST_FILE"
 }

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { ensureEnvFile } = require('./env');
-const { ensureDbLocation } = require('./paths');
+const { ensureDbLocation, ensureMinerRuntimeDir } = require('./paths');
 const { applyNodeConfiguration } = require('./node/configManager');
 const { ensureRpcCredentials } = require('./node/credentials');
 
@@ -56,6 +56,7 @@ async function runCli() {
     process.chdir(APP_ROOT);
     ensureEnvFile();
     ensureDbLocation(); // relocate the DB out of the checkout before ./db is required
+    ensureMinerRuntimeDir(); // relocate miner runtime files; create the dir before the miner starts
     knex = require('./db').knex;
     await bootstrap({ knex });
   } catch (error) {

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { ensureEnvFile } = require('./env');
+const { ensureDbLocation } = require('./paths');
 const { applyNodeConfiguration } = require('./node/configManager');
 const { ensureRpcCredentials } = require('./node/credentials');
 
@@ -54,6 +55,7 @@ async function runCli() {
   try {
     process.chdir(APP_ROOT);
     ensureEnvFile();
+    ensureDbLocation(); // relocate the DB out of the checkout before ./db is required
     knex = require('./db').knex;
     await bootstrap({ knex });
   } catch (error) {

--- a/src/configurator.js
+++ b/src/configurator.js
@@ -1,6 +1,7 @@
 const fsPromises = require('fs').promises;
 const _ = require('lodash');
 const { knex } = require('./db')
+const { getMinerRuntimeDir } = require('./paths');
 
 const generate = async function (pools = null, settings = null ) {
   	if (!settings) {
@@ -82,7 +83,7 @@ const generate = async function (pools = null, settings = null ) {
 
 	if (settings.powerLedOff) minerConfig += ` -pwrled off`;
 
-	const confDir = `${__dirname}/../backend/apollo-miner`;
+	const confDir = getMinerRuntimeDir();
 
 	try {
 		// Write all configuration file

--- a/src/devMinerService.js
+++ b/src/devMinerService.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const { getMinerRuntimeDir } = require('./paths');
 
 let devMinerInterval = null;
-const statsDir = path.resolve(__dirname, '../backend/apollo-miner/');
+const statsDir = getMinerRuntimeDir();
 const ckpoolDir = path.resolve(__dirname, '../backend/ckpool/logs');
 let statsFilePath = null;
 

--- a/src/env.js
+++ b/src/env.js
@@ -1,12 +1,13 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { defaultDatabaseUrl } = require('./paths');
 
 function ensureEnvFile() {
   const envPath = path.join(__dirname, '..', '.env');
   if (!fs.existsSync(envPath)) {
     const contents = [
-      `DATABASE_URL=${path.join(__dirname, '..', 'futurebit.sqlite')}`,
+      `DATABASE_URL=${defaultDatabaseUrl()}`,
       `APP_SECRET=${crypto.randomBytes(64).toString('hex')}`,
       '',
     ].join('\n');

--- a/src/init.js
+++ b/src/init.js
@@ -1,7 +1,10 @@
 const { ensureEnvFile } = require('./env');
+const { ensureDbLocation } = require('./paths');
 
 async function initializeApp() {
   ensureEnvFile();
+  ensureDbLocation(); // relocate the DB out of the checkout before ./db is required
+
   if (process.env.APOLLO_BOOTSTRAPPED !== '1') {
     // Manual and development launches do not have the systemd prerequisite.
     const { bootstrap } = require('./bootstrap');

--- a/src/init.js
+++ b/src/init.js
@@ -1,9 +1,10 @@
 const { ensureEnvFile } = require('./env');
-const { ensureDbLocation } = require('./paths');
+const { ensureDbLocation, ensureMinerRuntimeDir } = require('./paths');
 
 async function initializeApp() {
   ensureEnvFile();
   ensureDbLocation(); // relocate the DB out of the checkout before ./db is required
+  ensureMinerRuntimeDir(); // relocate miner runtime files out of the checkout
 
   if (process.env.APOLLO_BOOTSTRAPPED !== '1') {
     // Manual and development launches do not have the systemd prerequisite.

--- a/src/node/credentials.js
+++ b/src/node/credentials.js
@@ -1,17 +1,11 @@
 const crypto = require('crypto');
 const fs = require('fs').promises;
-const os = require('os');
 const path = require('path');
+const { getStateDir } = require('../paths');
 
 const CREDENTIALS_VERSION = 1;
 const LAN_USERNAME = 'futurebit';
 const CKPOOL_USERNAME = 'apollo-ckpool';
-
-function getStateDir() {
-  if (process.env.APOLLO_STATE_DIR) return process.env.APOLLO_STATE_DIR;
-  if (process.env.NODE_ENV === 'production') return '/var/lib/apollo';
-  return path.join(os.tmpdir(), 'apollo-runtime');
-}
 
 function getCredentialsPath(stateDir = getStateDir()) {
   return path.join(stateDir, 'rpc-credentials.json');

--- a/src/paths.js
+++ b/src/paths.js
@@ -94,13 +94,39 @@ function ensureDbLocation({ envPath = defaultEnvPath() } = {}) {
   rewriteEnvDatabaseUrl(envPath, desired);
 }
 
+// The in-checkout miner dir that also holds the binaries (which stay put).
+function getLegacyMinerDir() {
+  return path.join(__dirname, '..', 'backend', 'apollo-miner');
+}
+
+// Files the miner regenerates at runtime — moved out of the checkout. Binaries
+// (futurebit-miner*, apollo-helper) and the launch scripts stay in the checkout.
+const MINER_RUNTIME_FILES = ['miner_config', 'mode', 'miner_config3'];
+
+// Create the miner runtime dir (futurebit-owned) and, on first boot after an
+// upgrade, move the regenerated config files out of the checkout. The bootstrap
+// runs before the miner, so the dir exists (owned by futurebit) before the
+// root-owned miner writes its stat files into it. Idempotent; no-op in dev.
+function ensureMinerRuntimeDir({ legacyDir = getLegacyMinerDir() } = {}) {
+  if (!isManagedStateDir()) return;
+  const dir = getMinerRuntimeDir();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  for (const name of MINER_RUNTIME_FILES) {
+    const from = path.join(legacyDir, name);
+    const to = path.join(dir, name);
+    if (fs.existsSync(from) && !fs.existsSync(to)) moveFile(from, to);
+  }
+}
+
 module.exports = {
   getStateDir,
   getDbPath,
   getMinerRuntimeDir,
   getLegacyDbPath,
+  getLegacyMinerDir,
   isManagedStateDir,
   defaultEnvPath,
   defaultDatabaseUrl,
   ensureDbLocation,
+  ensureMinerRuntimeDir,
 };

--- a/src/paths.js
+++ b/src/paths.js
@@ -62,7 +62,9 @@ function rewriteEnvDatabaseUrl(envPath, dbUrl) {
   }
   const line = `DATABASE_URL=${dbUrl}`;
   if (/^DATABASE_URL=.*$/m.test(contents)) {
-    contents = contents.replace(/^DATABASE_URL=.*$/m, line);
+    // Replacer callback, so a '$' sequence in the path is not treated as a
+    // replacement pattern ($&, $1, ...) and corrupt the written line.
+    contents = contents.replace(/^DATABASE_URL=.*$/m, () => line);
   } else {
     contents = contents.replace(/\n*$/, '\n') + line + '\n';
   }
@@ -107,10 +109,15 @@ const MINER_RUNTIME_FILES = ['miner_config', 'mode', 'miner_config3'];
 // upgrade, move the regenerated config files out of the checkout. The bootstrap
 // runs before the miner, so the dir exists (owned by futurebit) before the
 // root-owned miner writes its stat files into it. Idempotent; no-op in dev.
+//
+// 0700 is what this actually gets: apollo-bootstrap.service runs with
+// UMask=0077, and the parent state dir is 0700 anyway. Access is covered by
+// ownership — futurebit owns the dir, and the root-owned miner bypasses the
+// mode bits.
 function ensureMinerRuntimeDir({ legacyDir = getLegacyMinerDir() } = {}) {
   if (!isManagedStateDir()) return;
   const dir = getMinerRuntimeDir();
-  fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   for (const name of MINER_RUNTIME_FILES) {
     const from = path.join(legacyDir, name);
     const to = path.join(dir, name);

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,0 +1,106 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Single source of truth for where mutable runtime state lives, so the code
+// checkout can stay clean/read-only for prebuilt (OTA) updates.
+//
+// - APOLLO_STATE_DIR wins (tests, overrides).
+// - production defaults to /var/lib/apollo (systemd StateDirectory=apollo).
+// - development/test fall back to a throwaway tmp dir.
+function getStateDir() {
+  if (process.env.APOLLO_STATE_DIR) return process.env.APOLLO_STATE_DIR;
+  if (process.env.NODE_ENV === 'production') return '/var/lib/apollo';
+  return path.join(os.tmpdir(), 'apollo-runtime');
+}
+
+function getDbPath(stateDir = getStateDir()) {
+  return path.join(stateDir, 'db', 'futurebit.sqlite');
+}
+
+function getMinerRuntimeDir(stateDir = getStateDir()) {
+  return path.join(stateDir, 'miner');
+}
+
+// True when we manage runtime state under a state dir (production, or an
+// explicit APOLLO_STATE_DIR). In plain development the DB stays in the repo.
+function isManagedStateDir() {
+  return process.env.NODE_ENV === 'production' || !!process.env.APOLLO_STATE_DIR;
+}
+
+// The legacy in-checkout DB location used before state was relocated.
+function getLegacyDbPath() {
+  return path.join(__dirname, '..', 'futurebit.sqlite');
+}
+
+function defaultEnvPath() {
+  return path.join(__dirname, '..', '.env');
+}
+
+// The DATABASE_URL a fresh install should be created with.
+function defaultDatabaseUrl() {
+  return isManagedStateDir() ? getDbPath() : getLegacyDbPath();
+}
+
+function moveFile(from, to) {
+  try {
+    fs.renameSync(from, to);
+  } catch (err) {
+    // /opt and /var/lib may live on different mounts → rename gives EXDEV.
+    if (err.code !== 'EXDEV') throw err;
+    fs.copyFileSync(from, to);
+    fs.unlinkSync(from);
+  }
+}
+
+function rewriteEnvDatabaseUrl(envPath, dbUrl) {
+  let contents = '';
+  try {
+    contents = fs.readFileSync(envPath, 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+  const line = `DATABASE_URL=${dbUrl}`;
+  if (/^DATABASE_URL=.*$/m.test(contents)) {
+    contents = contents.replace(/^DATABASE_URL=.*$/m, line);
+  } else {
+    contents = contents.replace(/\n*$/, '\n') + line + '\n';
+  }
+  fs.writeFileSync(envPath, contents, { mode: 0o600 });
+  fs.chmodSync(envPath, 0o600);
+}
+
+// Relocate the sqlite DB into the managed state dir on first boot, and keep
+// .env + process.env in sync. Idempotent. MUST run before ./db is required,
+// because knex resolves DATABASE_URL at require time.
+function ensureDbLocation({ envPath = defaultEnvPath() } = {}) {
+  if (!isManagedStateDir()) return; // dev/test: leave the repo DB in place
+
+  const desired = getDbPath();
+  fs.mkdirSync(path.dirname(desired), { recursive: true, mode: 0o700 });
+
+  const current = process.env.DATABASE_URL;
+  if (current && path.resolve(current) === path.resolve(desired)) return;
+
+  // Move a legacy DB (and its -wal/-shm siblings) if present and not yet moved.
+  if (current && fs.existsSync(current) && !fs.existsSync(desired)) {
+    for (const suffix of ['', '-wal', '-shm']) {
+      const from = current + suffix;
+      if (fs.existsSync(from)) moveFile(from, desired + suffix);
+    }
+  }
+
+  process.env.DATABASE_URL = desired;
+  rewriteEnvDatabaseUrl(envPath, desired);
+}
+
+module.exports = {
+  getStateDir,
+  getDbPath,
+  getMinerRuntimeDir,
+  getLegacyDbPath,
+  isManagedStateDir,
+  defaultEnvPath,
+  defaultDatabaseUrl,
+  ensureDbLocation,
+};

--- a/src/services/logs.js
+++ b/src/services/logs.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { exec } = require('child_process');
 const util = require('util');
 const { GraphQLError } = require('graphql');
+const { getMinerRuntimeDir } = require('../paths');
 
 // Convert exec to use promises
 const execPromise = util.promisify(exec);
@@ -107,10 +108,7 @@ class LogsService {
             }
           } else {
             // Fallback to the log file path for development
-            logPath = path.resolve(
-              __dirname,
-              '../../backend/apollo-miner/miner.log'
-            );
+            logPath = path.join(getMinerRuntimeDir(), 'miner.log');
           }
           break;
         case 'APOLLO_API':

--- a/src/services/miner.js
+++ b/src/services/miner.js
@@ -4,6 +4,7 @@ const { exec } = require('child_process');
 const _ = require('lodash');
 const moment = require('moment');
 const { GraphQLError } = require('graphql');
+const { getMinerRuntimeDir } = require('../paths');
 
 // Import the dev miner service for development mode
 const devMinerService =
@@ -271,7 +272,7 @@ class MinerService {
   // Helper method to check if miner is online
   async _isMinerOnline(dbStatus) {
     try {
-      const statsDir = path.resolve(__dirname, '../../backend/apollo-miner/');
+      const statsDir = getMinerRuntimeDir();
       const statsFilePattern = /^apollo-miner.*$/;
 
       // Define thresholds
@@ -443,7 +444,7 @@ class MinerService {
 
     // --- USB boards (apollo-miner) ---
     try {
-      const statsDir = path.resolve(__dirname, '../../backend/apollo-miner/');
+      const statsDir = getMinerRuntimeDir();
       const statsFilePattern = /^apollo-miner.*$/;
       let statsFiles = await fs.readdir(statsDir);
       // The Apollo III stat file lives in the same dir but is read separately.
@@ -486,8 +487,7 @@ class MinerService {
     // the III binary; there is no separate systemd unit.
     try {
       const iiiStatsDir =
-        process.env.APOLLO_III_STATS_DIR ||
-        path.resolve(__dirname, '../../backend/apollo-miner/');
+        process.env.APOLLO_III_STATS_DIR || getMinerRuntimeDir();
       const iiiPath = `${iiiStatsDir}/apollo-miner-3.json`;
       await fs.access(iiiPath);
       const parsed = await this._parseStatFileEntry(iiiPath, {

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -127,3 +127,63 @@ describe('ensureDbLocation', () => {
     expect(fs.readFileSync(desired, 'utf8')).toBe('DB');
   });
 });
+
+describe('ensureMinerRuntimeDir', () => {
+  function managedMiner() {
+    const stateDir = path.join(tmpRoot, 'state');
+    process.env.APOLLO_STATE_DIR = stateDir;
+    const legacyDir = path.join(tmpRoot, 'checkout', 'backend', 'apollo-miner');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    return { minerDir: path.join(stateDir, 'miner'), legacyDir };
+  }
+
+  it('is a no-op in development', () => {
+    delete process.env.APOLLO_STATE_DIR;
+    process.env.NODE_ENV = 'development';
+    const legacyDir = path.join(tmpRoot, 'checkout');
+    fs.mkdirSync(legacyDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, 'miner_config'), 'CFG');
+
+    paths.ensureMinerRuntimeDir({ legacyDir });
+
+    // Nothing created under a state dir, legacy file untouched.
+    expect(fs.readFileSync(path.join(legacyDir, 'miner_config'), 'utf8')).toBe(
+      'CFG'
+    );
+  });
+
+  it('creates the runtime dir and moves regenerated config out of the checkout', () => {
+    const { minerDir, legacyDir } = managedMiner();
+    fs.writeFileSync(path.join(legacyDir, 'miner_config'), 'CFG');
+    fs.writeFileSync(path.join(legacyDir, 'mode'), 'eco');
+    fs.writeFileSync(path.join(legacyDir, 'miner_config3'), 'turbo');
+    // A binary must stay in the checkout, not be moved.
+    fs.writeFileSync(path.join(legacyDir, 'futurebit-miner'), 'ELF');
+
+    paths.ensureMinerRuntimeDir({ legacyDir });
+
+    expect(fs.readFileSync(path.join(minerDir, 'miner_config'), 'utf8')).toBe(
+      'CFG'
+    );
+    expect(fs.readFileSync(path.join(minerDir, 'mode'), 'utf8')).toBe('eco');
+    expect(fs.readFileSync(path.join(minerDir, 'miner_config3'), 'utf8')).toBe(
+      'turbo'
+    );
+    expect(fs.existsSync(path.join(legacyDir, 'miner_config'))).toBe(false);
+    expect(fs.existsSync(path.join(legacyDir, 'futurebit-miner'))).toBe(true);
+  });
+
+  it('creates the dir even with no legacy files, and does not clobber existing runtime config', () => {
+    const { minerDir, legacyDir } = managedMiner();
+    fs.mkdirSync(minerDir, { recursive: true });
+    fs.writeFileSync(path.join(minerDir, 'miner_config'), 'CURRENT');
+    fs.writeFileSync(path.join(legacyDir, 'miner_config'), 'STALE');
+
+    paths.ensureMinerRuntimeDir({ legacyDir });
+
+    // Existing runtime config wins; the stale checkout copy is left in place.
+    expect(fs.readFileSync(path.join(minerDir, 'miner_config'), 'utf8')).toBe(
+      'CURRENT'
+    );
+  });
+});

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -1,0 +1,129 @@
+// tests/paths.test.js
+// ensureDbLocation() relocates the sqlite DB out of the code checkout into the
+// managed state dir on first boot and keeps .env / process.env in sync. It runs
+// before ./db is required, so it is plain sync fs work driven by env vars.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const paths = require('../src/paths');
+
+let tmpRoot;
+let savedEnv;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'apollo-paths-'));
+  savedEnv = {
+    APOLLO_STATE_DIR: process.env.APOLLO_STATE_DIR,
+    DATABASE_URL: process.env.DATABASE_URL,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  jest.restoreAllMocks();
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function managed() {
+  const stateDir = path.join(tmpRoot, 'state');
+  process.env.APOLLO_STATE_DIR = stateDir;
+  return {
+    stateDir,
+    desired: path.join(stateDir, 'db', 'futurebit.sqlite'),
+    envPath: path.join(tmpRoot, '.env'),
+  };
+}
+
+describe('ensureDbLocation', () => {
+  it('is a no-op in development (DB stays in the checkout)', () => {
+    delete process.env.APOLLO_STATE_DIR;
+    process.env.NODE_ENV = 'development';
+    const envPath = path.join(tmpRoot, '.env');
+    fs.writeFileSync(envPath, 'DATABASE_URL=/repo/futurebit.sqlite\n');
+    process.env.DATABASE_URL = '/repo/futurebit.sqlite';
+
+    paths.ensureDbLocation({ envPath });
+
+    expect(process.env.DATABASE_URL).toBe('/repo/futurebit.sqlite');
+    expect(fs.readFileSync(envPath, 'utf8')).toContain(
+      'DATABASE_URL=/repo/futurebit.sqlite'
+    );
+  });
+
+  it('points a fresh install at the managed DB path and rewrites .env', () => {
+    const { desired, envPath } = managed();
+    fs.writeFileSync(envPath, 'APP_SECRET=deadbeef\n');
+    delete process.env.DATABASE_URL; // fresh: nothing set yet
+
+    paths.ensureDbLocation({ envPath });
+
+    expect(process.env.DATABASE_URL).toBe(desired);
+    expect(fs.existsSync(path.dirname(desired))).toBe(true);
+    const env = fs.readFileSync(envPath, 'utf8');
+    expect(env).toContain(`DATABASE_URL=${desired}`);
+    expect(env).toContain('APP_SECRET=deadbeef'); // preserved
+  });
+
+  it('moves a legacy DB and its -wal/-shm siblings, then rewrites .env', () => {
+    const { desired, envPath } = managed();
+    const legacy = path.join(tmpRoot, 'futurebit.sqlite');
+    fs.writeFileSync(legacy, 'MAINDB');
+    fs.writeFileSync(`${legacy}-wal`, 'WAL');
+    fs.writeFileSync(`${legacy}-shm`, 'SHM');
+    fs.writeFileSync(envPath, `DATABASE_URL=${legacy}\nAPP_SECRET=x\n`);
+    process.env.DATABASE_URL = legacy;
+
+    paths.ensureDbLocation({ envPath });
+
+    expect(fs.existsSync(legacy)).toBe(false);
+    expect(fs.readFileSync(desired, 'utf8')).toBe('MAINDB');
+    expect(fs.readFileSync(`${desired}-wal`, 'utf8')).toBe('WAL');
+    expect(fs.readFileSync(`${desired}-shm`, 'utf8')).toBe('SHM');
+    expect(process.env.DATABASE_URL).toBe(desired);
+    expect(fs.readFileSync(envPath, 'utf8')).toContain(
+      `DATABASE_URL=${desired}`
+    );
+  });
+
+  it('falls back to copy+unlink when rename crosses filesystems (EXDEV)', () => {
+    const { desired, envPath } = managed();
+    const legacy = path.join(tmpRoot, 'futurebit.sqlite');
+    fs.writeFileSync(legacy, 'CROSSFS');
+    fs.writeFileSync(envPath, `DATABASE_URL=${legacy}\n`);
+    process.env.DATABASE_URL = legacy;
+
+    const realRename = fs.renameSync;
+    jest.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      const err = new Error('cross-device link');
+      err.code = 'EXDEV';
+      throw err;
+    });
+
+    paths.ensureDbLocation({ envPath });
+    fs.renameSync = realRename;
+
+    expect(fs.existsSync(legacy)).toBe(false);
+    expect(fs.readFileSync(desired, 'utf8')).toBe('CROSSFS');
+  });
+
+  it('is idempotent once the DB already lives in the managed path', () => {
+    const { desired, envPath } = managed();
+    fs.mkdirSync(path.dirname(desired), { recursive: true });
+    fs.writeFileSync(desired, 'DB');
+    fs.writeFileSync(envPath, `DATABASE_URL=${desired}\n`);
+    process.env.DATABASE_URL = desired;
+
+    const renameSpy = jest.spyOn(fs, 'renameSync');
+    paths.ensureDbLocation({ envPath });
+
+    expect(renameSpy).not.toHaveBeenCalled();
+    expect(process.env.DATABASE_URL).toBe(desired);
+    expect(fs.readFileSync(desired, 'utf8')).toBe('DB');
+  });
+});

--- a/tests/paths.test.js
+++ b/tests/paths.test.js
@@ -112,6 +112,23 @@ describe('ensureDbLocation', () => {
     expect(fs.readFileSync(desired, 'utf8')).toBe('CROSSFS');
   });
 
+  it('writes the path verbatim when it contains a $ replacement sequence', () => {
+    // '$&' etc. must not be interpreted as a String.replace pattern.
+    const stateDir = path.join(tmpRoot, 'st$&ate');
+    process.env.APOLLO_STATE_DIR = stateDir;
+    const desired = path.join(stateDir, 'db', 'futurebit.sqlite');
+    const envPath = path.join(tmpRoot, '.env');
+    fs.writeFileSync(envPath, 'DATABASE_URL=/old/futurebit.sqlite\n');
+    process.env.DATABASE_URL = '/old/futurebit.sqlite';
+
+    paths.ensureDbLocation({ envPath });
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain(
+      `DATABASE_URL=${desired}`
+    );
+    expect(process.env.DATABASE_URL).toBe(desired);
+  });
+
   it('is idempotent once the DB already lives in the managed path', () => {
     const { desired, envPath } = managed();
     fs.mkdirSync(path.dirname(desired), { recursive: true });


### PR DESCRIPTION
Keep the code checkout clean/read-only for prebuilt OTA updates by moving all mutable runtime state into the managed state dir (`/var/lib/apollo`, systemd `StateDirectory=apollo`). Two commits.

**DB** → `${stateDir}/db/futurebit.sqlite`
- New `src/paths.js`: single source of truth for the state dir (`getStateDir` moved here, `credentials.js` re-exports it).
- `ensureDbLocation()` runs in `init.js`/`bootstrap.js` before `./db` is required (knex resolves `DATABASE_URL` at require time): creates the db dir, moves a legacy in-checkout DB plus its `-wal`/`-shm` siblings (rename with EXDEV copy+unlink fallback), rewrites `DATABASE_URL` in `.env` and `process.env`. Idempotent; no-op in dev.

**Miner runtime** → `${stateDir}/miner/`
- `miner_config`/`mode`/`miner_config3` + `apollo-miner.*` stat files leave the checkout; binaries and launch scripts stay.
- `configurator`/`miner`/`logs`/`devMinerService` use `getMinerRuntimeDir()`. `ensureMinerRuntimeDir()` creates the dir and one-time-moves regenerated config out of the checkout (idempotent, no-op in dev).
- `miner_start.sh` runs from the runtime dir and calls binaries by absolute path from the checkout, so stat files land in the runtime dir.
- `apollo-miner.service` `Requires`/`After apollo-bootstrap` so the futurebit-owned runtime dir exists before the root-owned miner writes into it; stat files are world-readable so the futurebit API can read them.

Backend suite green (434), +8 tests for `ensureDbLocation`/`ensureMinerRuntimeDir`.

**Note:** miner behavior (screen, stat files) needs on-device validation on apollo2 before merge; the DB path is covered by tests.